### PR TITLE
fix: change backgournd color to have more contrast

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4,5 +4,5 @@
   border-radius: 50%;
 }
 body{
-  background-color: #fa61de;
+  background-color: #f1a7e4;
 }


### PR DESCRIPTION
This pull request adds a change to the background color to make it easier to read the text.  The pink color did not compliment the black text and made it hard to read the page text.

Before:

![image](https://user-images.githubusercontent.com/5313213/89355420-33aedb00-d670-11ea-8ecc-d9ace31ae697.png)

After:
![image](https://user-images.githubusercontent.com/5313213/89355449-40cbca00-d670-11ea-90cb-718f49b53e87.png)

If you have a different color suggestion than the one I have chosen, feel free to make a suggestion and I will adjust my PR.

This repo is a great idea to help users become more familiar with Git and GitHub.  Thanks for creating it.