### PR TITLE
fix: Prevent comments slide from flashing on page load

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -44,6 +44,10 @@
 #reviewFade .carousel-control-prev:hover,#reviewFade .carousel-control-next:hover{
   opacity: 0.7;
 }
+.hidden {
+  display: none;
+}
+
 .btn_div{
   text-align: center;
 }

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -1,7 +1,5 @@
 // jquery to hide and toggle the comments until button is clicked
 
-$('#randSec').hide('');
-
 // toggle function
 $('#btn_com').click(function(){
     $('#randSec').toggle('');

--- a/contributors.md
+++ b/contributors.md
@@ -1,3 +1,4 @@
 # Contributors
 - [David Fraser](https://github.com/DavidMatthewFraser)
 - [Fortune Okon](https://github.com/fort3)
+- [Randell Dawson](https://github.com/RandellDawson)

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       </div>
 
       <!-- a section including a carousel slide from bootstrap.-->
-    <section id="randSec">
+    <section id="randSec" class="hidden">
       <p>
         <h2 style="margin-left: 6%;
           margin-top: 4%;">Carousel Comments Slide</h2>


### PR DESCRIPTION
This PR fixes a small bug where when the page loads, the carousel was showing very briefly, which caused the page to "flash".

Also, added my name to the `contributors.md` file.

**Question:** Do you want to have the names in the `contributors.md` file load into the footer or do you want to keep just your name in the footer.