### PR TITLE
fix: change button text to match current state of comment slider

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -3,7 +3,7 @@
 function changeButtonName(button) {
   var currentBtnText = $(button).text();
   var buttonAction = currentBtnText.includes('see') ? 'hide' : 'see';
-  $(button).text('Click to ' + buttonAction + ' Comments Slide');
+  $(button).text('Click to ' + buttonAction + ' Comments');
 }
 
 // toggle function

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -1,8 +1,14 @@
 // jquery to hide and toggle the comments until button is clicked
 
+function changeButtonName(button) {
+  var currentBtnText = $(button).text();
+  var buttonAction = currentBtnText.includes('see') ? 'hide' : 'see';
+  $(button).text('Click to ' + buttonAction + ' Comments Slide');
+}
+
 // toggle function
 $('#btn_com').click(function(){
-    $('#randSec').toggle('');
+  $('#randSec').toggle('swing', changeButtonName.bind(null, this));
 });
 
 console.log('Easy to Function')

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       the code can potentially break!</p>
 
       <div class="btn_div">
-        <button id="btn_com" class="btn btn-primary">Click to see Comments Slide</button>
+        <button id="btn_com" class="btn btn-primary">Click to see Comments</button>
       </div>
 
       <!-- a section including a carousel slide from bootstrap.-->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       the code can potentially break!</p>
 
       <div class="btn_div">
-        <button id="btn_com" class="btn btn-primary"> Click to see Comments Slide</button>
+        <button id="btn_com" class="btn btn-primary">Click to see Comments Slide</button>
       </div>
 
       <!-- a section including a carousel slide from bootstrap.-->


### PR DESCRIPTION
This PR changes the text of the button based on whether or not the comment slider is showing or not.

If the comments slider is showing, the text is `Click to hide Comments`.
If the comments slider is not showing, the text is `Click to see Comments`.

Since the button really just shows or hides the comments and does not make the comments slide or not slide, I thought it made sense to remove the word `Slide` from the end of the button text.  I can change it back if you do not agree.