### PR TITLE
fix: changed date to use toLocaleDateString

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -11,16 +11,14 @@ $('#btn_com').click(function(){
   $('#randSec').toggle('swing', changeButtonName.bind(null, this));
 });
 
-// console.log('Easy to Function')
-
 
 // display time 
 // added by theTradeCoder
 function displayTime() {  
   setInterval(() => {
     const date = new Date();
-    $("#date").html(`${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()},`);
-    $("#time").html(`${date.toLocaleTimeString()}`)
+    $("#date").html(date.toLocaleDateString());
+    $("#time").html(date.toLocaleTimeString());
   }, 1000);
 };
 displayTime();


### PR DESCRIPTION
The date was set for a European style vs. local style.  Those in the US typically use the mm-dd-yyyy format, so using `toLocaleDateString` should satisfy most users regardless where they are located.