### PR TITLE
added a description to get a better google search

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>EasyToGit</title>
+  <meta name="description" content="Learn how easy it is to learn git by practicing with an actual remote repository.  Start Now!">
   <!-- Fontawesome CDN-->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" />
   <!-- Bootstrap CDN-->


### PR DESCRIPTION
I googled 'easytogit' to see what google would put up.  Here is the result:

![Screen Shot 2020-08-24 at 9 23 21 AM](https://user-images.githubusercontent.com/51532684/91070520-af56d480-e5eb-11ea-98ee-1195f7ffb234.png)

I'm hoping that **adding a description** would help google give a better description for easytogit.com

Notice: David's youtube tutorials show up at the top.

Keywords I thought people would search: 'learn git' 'how do I use git on a remote repository'  Here is what I came up with as a first draft:  "**Learn how easy it is to learn git by practicing with an actual remote repository.  Start Now!**"

I just notice I used 'learn' twice.  Maybe we should think of another keyword to replace the first 'Learn'.
