### PR TITLE
Weather Widget scroll behavior

### DIFF
--- a/widgets/widgets.html
+++ b/widgets/widgets.html
@@ -108,9 +108,9 @@
         </form>
       </div>
       <div class="display hidden">
-        <img src="http://placehold.jp/400x300.png" width="300" height="400" alt="image that shows whether it is day or night">
+        <img src="http://placehold.jp/400x300.png">
         <div class="icon">
-          <img src="" width="100" height="100" alt="icon that shows the weather conditions, such as rain, sunny, windy">
+          <img src="">
         </div>
         <div class="details">
           <h5>City</h5>

--- a/widgets/widgets.html
+++ b/widgets/widgets.html
@@ -108,9 +108,9 @@
         </form>
       </div>
       <div class="display hidden">
-        <img src="http://placehold.jp/400x300.png">
+        <img src="http://placehold.jp/400x300.png" width="300" height="400" alt="image that shows whether it is day or night">
         <div class="icon">
-          <img src="">
+          <img src="" width="100" height="100" alt="icon that shows the weather conditions, such as rain, sunny, windy">
         </div>
         <div class="details">
           <h5>City</h5>

--- a/widgets/widgets.js
+++ b/widgets/widgets.js
@@ -43,6 +43,7 @@ const getCity = async (city) => {
   const query = `?apikey=${key}&q=${city}`;
   const response = await fetch(base + query);
   const data = await response.json();
+  console.log(data[0]);
   return data[0];
 }
 
@@ -51,12 +52,14 @@ const getWeather = async (cityId) => {
   const query = `${cityId}?apikey=${key}`;
   const response = await fetch(base + query);
   const data = await response.json();
+  console.log(data);
   return data[0];
 }
 
 const updateDisplay = data => {
   const cityDetails = data.cityDetails;
   const weather = data.weather;
+
   details.innerHTML = `
     <h5>${cityDetails.EnglishName}</h5>
     <div class="condition">${weather.WeatherText}</div>
@@ -73,20 +76,26 @@ const updateDisplay = data => {
     imageSource = 'images/night.svg';
   }
   image.setAttribute('src', imageSource);
+
   const iconSource = `images/icons/${weather.WeatherIcon}.svg`;
   icon.setAttribute('src', iconSource);
+
   if (display.classList.contains('hidden')) {
     display.classList.remove('hidden');
   }
-  $('#bottom')[0].scrollIntoView({
-    behavior: 'smooth',
-    block: 'end',
-    inline: 'nearest'
-  });
+
+  //display.scrollIntoView();
+
+  //$('#bottom')[0].scrollIntoView({
+  //  behavior: 'smooth',
+  //  block: 'end',
+  //  inline: 'nearest'
+  //});
   // Please Help Here
   // I would like the <div class='display'> to be
   // located at the bottom of the screen.
-  // I tried:  display.scrollIntoView(false);
+  // I tried:
+
 }
 
 const updateCity = async (city) => {
@@ -105,5 +114,6 @@ cityForm.addEventListener('submit', e => {
   updateCity(city)
     .then(data => updateDisplay(data))
     .catch(err => console.log(err));
+  display.scrollIntoView(false);
 })
 

--- a/widgets/widgets.js
+++ b/widgets/widgets.js
@@ -57,6 +57,7 @@ const getWeather = async (cityId) => {
 const updateDisplay = data => {
   const cityDetails = data.cityDetails;
   const weather = data.weather;
+
   details.innerHTML = `
     <h5>${cityDetails.EnglishName}</h5>
     <div class="condition">${weather.WeatherText}</div>

--- a/widgets/widgets.js
+++ b/widgets/widgets.js
@@ -84,6 +84,8 @@ const updateDisplay = data => {
 
   //display.scrollIntoView();
 
+  document.querySelector('.display').scrollIntoView(false);
+
   //$('#bottom')[0].scrollIntoView({
   //  behavior: 'smooth',
   //  block: 'end',
@@ -113,6 +115,5 @@ cityForm.addEventListener('submit', e => {
   updateCity(city)
     .then(data => updateDisplay(data))
     .catch(err => console.log(err));
-  display.scrollIntoView(false);
 })
 

--- a/widgets/widgets.js
+++ b/widgets/widgets.js
@@ -9,6 +9,7 @@ function changeButtonName(button) {
 $('#btn_com').click(function(){
   $('#randSec').toggle('swing', changeButtonName.bind(null, this));
 });
+
 // display time 
 // added by theTradeCoder
 function displayTime() {  
@@ -19,6 +20,7 @@ function displayTime() {
   }, 1000);
 };
 displayTime();
+
 // google search option 
 // added by Mamun Abdullah, @theTradeCoder
 $('#googleSearch').submit((e)=>{
@@ -28,6 +30,7 @@ $('#googleSearch').submit((e)=>{
       let searchUrl = `https://www.google.com/search?q=${searchTopic}&oq=${searchTopic}&ie=UTF-8`;
      window.open(searchUrl);
     });
+
 // weather ninja widget
 // added by Terri Fricker, based on tutorial by NetNinja
 const key = 'SIOTsEz9ysEBcldZ8iAw1eHDwA4F3iAg';
@@ -36,8 +39,6 @@ const display = document.querySelector('.display');
 const details = document.querySelector('.details');
 const image = document.querySelector('.display img');
 const icon = document.querySelector('.icon img');
-
-
 const getCity = async (city) => {
   const base = 'http://dataservice.accuweather.com/locations/v1/cities/search';
   const query = `?apikey=${key}&q=${city}`;
@@ -45,7 +46,6 @@ const getCity = async (city) => {
   const data = await response.json();
   return data[0];
 }
-
 const getWeather = async (cityId) => {
   const base = 'http://dataservice.accuweather.com/currentconditions/v1/';
   const query = `${cityId}?apikey=${key}`;
@@ -53,12 +53,10 @@ const getWeather = async (cityId) => {
   const data = await response.json();
   return data[0];
 }
-
 const updateDisplay = data => {
   const cityDetails = data.cityDetails;
   const weather = data.weather;
-
-  details.innerHTML = `
+    details.innerHTML = `
     <h5>${cityDetails.EnglishName}</h5>
     <div class="condition">${weather.WeatherText}</div>
     <div class="temperature">
@@ -66,7 +64,6 @@ const updateDisplay = data => {
       <span>&deg;F</span>
     </div>
   `;
-
   let imageSource = null;
   if(weather.IsDayTime) {
     imageSource = 'images/day.svg';
@@ -74,30 +71,13 @@ const updateDisplay = data => {
     imageSource = 'images/night.svg';
   }
   image.setAttribute('src', imageSource);
-
   const iconSource = `images/icons/${weather.WeatherIcon}.svg`;
   icon.setAttribute('src', iconSource);
-
   if (display.classList.contains('hidden')) {
     display.classList.remove('hidden');
   }
-
-  //display.scrollIntoView();
-
   document.querySelector('.display').scrollIntoView(false);
-
-  //$('#bottom')[0].scrollIntoView({
-  //  behavior: 'smooth',
-  //  block: 'end',
-  //  inline: 'nearest'
-  //});
-  // Please Help Here
-  // I would like the <div class='display'> to be
-  // located at the bottom of the screen.
-  // I tried:
-
 }
-
 const updateCity = async (city) => {
   const cityDetails = await getCity(city);
   const weather = await getWeather(cityDetails.Key);
@@ -106,8 +86,6 @@ const updateCity = async (city) => {
     weather: weather
   }
 };
-
-
 cityForm.addEventListener('submit', e => {
   e.preventDefault();
   const city = cityForm.city.value.trim();
@@ -115,5 +93,5 @@ cityForm.addEventListener('submit', e => {
   updateCity(city)
     .then(data => updateDisplay(data))
     .catch(err => console.log(err));
-})
+});
 

--- a/widgets/widgets.js
+++ b/widgets/widgets.js
@@ -74,20 +74,26 @@ const updateDisplay = data => {
     imageSource = 'images/night.svg';
   }
   image.setAttribute('src', imageSource);
+
   const iconSource = `images/icons/${weather.WeatherIcon}.svg`;
   icon.setAttribute('src', iconSource);
+
   if (display.classList.contains('hidden')) {
     display.classList.remove('hidden');
   }
-  $('#bottom')[0].scrollIntoView({
-    behavior: 'smooth',
-    block: 'end',
-    inline: 'nearest'
-  });
+
+  //display.scrollIntoView();
+
+  //$('#bottom')[0].scrollIntoView({
+  //  behavior: 'smooth',
+  //  block: 'end',
+  //  inline: 'nearest'
+  //});
   // Please Help Here
   // I would like the <div class='display'> to be
   // located at the bottom of the screen.
-  // I tried:  display.scrollIntoView(false);
+  // I tried:
+
 }
 
 const updateCity = async (city) => {
@@ -99,6 +105,7 @@ const updateCity = async (city) => {
   }
 };
 
+
 cityForm.addEventListener('submit', e => {
   e.preventDefault();
   const city = cityForm.city.value.trim();
@@ -106,5 +113,6 @@ cityForm.addEventListener('submit', e => {
   updateCity(city)
     .then(data => updateDisplay(data))
     .catch(err => console.log(err));
+  display.scrollIntoView(false);
 })
 

--- a/widgets/widgets.js
+++ b/widgets/widgets.js
@@ -43,7 +43,6 @@ const getCity = async (city) => {
   const query = `?apikey=${key}&q=${city}`;
   const response = await fetch(base + query);
   const data = await response.json();
-  console.log(data[0]);
   return data[0];
 }
 
@@ -52,14 +51,12 @@ const getWeather = async (cityId) => {
   const query = `${cityId}?apikey=${key}`;
   const response = await fetch(base + query);
   const data = await response.json();
-  console.log(data);
   return data[0];
 }
 
 const updateDisplay = data => {
   const cityDetails = data.cityDetails;
   const weather = data.weather;
-
   details.innerHTML = `
     <h5>${cityDetails.EnglishName}</h5>
     <div class="condition">${weather.WeatherText}</div>
@@ -76,26 +73,20 @@ const updateDisplay = data => {
     imageSource = 'images/night.svg';
   }
   image.setAttribute('src', imageSource);
-
   const iconSource = `images/icons/${weather.WeatherIcon}.svg`;
   icon.setAttribute('src', iconSource);
-
   if (display.classList.contains('hidden')) {
     display.classList.remove('hidden');
   }
-
-  //display.scrollIntoView();
-
-  //$('#bottom')[0].scrollIntoView({
-  //  behavior: 'smooth',
-  //  block: 'end',
-  //  inline: 'nearest'
-  //});
+  $('#bottom')[0].scrollIntoView({
+    behavior: 'smooth',
+    block: 'end',
+    inline: 'nearest'
+  });
   // Please Help Here
   // I would like the <div class='display'> to be
   // located at the bottom of the screen.
-  // I tried:
-
+  // I tried:  display.scrollIntoView(false);
 }
 
 const updateCity = async (city) => {
@@ -114,6 +105,5 @@ cityForm.addEventListener('submit', e => {
   updateCity(city)
     .then(data => updateDisplay(data))
     .catch(err => console.log(err));
-  display.scrollIntoView(false);
 })
 


### PR DESCRIPTION
The Weather Widget was intended to scroll down once the display is updated to show the entire display `<div>`.  It did not scroll correctly the first time a city is entered, but worked on subsequent cities entered.

One thought I had was that some internal process didn't know the height of .display when it calculates the position for scrollIntoView(), but we don't call it until after the '.hidden' attribute is removed.  I tried adding width and height to my html image tags, but that didn't work the first time either.

I think the problem was that I was calling scrollIntoView() on a
`const display = document.querySelector('.display');`
that was run at the beginning of the javascript _prior_ to becoming 'unhidden', then using the same reference for calling scrollIntoView():
`  display.scrollIntoView(false);`
_after_ the the display was 'unhidden'.

Calling the scrollIntoView() on a new reference of the display <div> once the display was 'unhidden' worked each time the method was called.
`document.querySelector('.display').scrollIntoView(false);`

Closes issue #180
