### PR TITLE
Rearrange useful links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Don't track content of these folders
+node_modules/
+.vscode/
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/useful-links/useful-links.html
+++ b/useful-links/useful-links.html
@@ -239,9 +239,10 @@
             <p> {Description of Book} </p>
           </figcaption>
         </figure>
-      </div> -->
+      </div> 
+-->
 
-      
+
     </div>  <!-- end of container of all book cards -->
 
 

--- a/useful-links/useful-links.html
+++ b/useful-links/useful-links.html
@@ -82,7 +82,7 @@
 
 
 
-  
+
 <!-- Container for all of the links -->
   <div class="info-container">
 
@@ -138,19 +138,6 @@
 
 
 
-
-<!-- Online Courses -->
-    <div class="list">
-      <div class="info-header">
-        <img src="img/online-course.png" alt="">
-        <h3 id="courses">Online Courses</h3>
-      </div>
-      <p>There are tons of online courses which teach web development at every level. Also, most of them are really cheap or even free! Here are the best of them:</p>
-      <ul>
-        <li><a href="https://www.udemy.com/course/the-web-developer-bootcamp/"><img src="img/udemy.png" alt=""></a>The Web Developer Bootcamp 2.0</li>
-        <li><a href="https://www.coursera.org/learn/html-css-javascript-for-web-developers"><img src="img/johnhop.png" alt=""></a>HTML, CSS, and Javascript for Web Developers</li>
-      </ul>
-    </div>
 
 
 
@@ -229,7 +216,23 @@
       </figure>
       </div> -->
 
-    </div>
+    </div>  <!-- end of container of all book cards -->
+
+
+
+    
+<!-- Online Courses -->
+<div class="list">
+  <div class="info-header">
+    <img src="img/online-course.png" alt="">
+    <h3 id="courses">Online Courses</h3>
+  </div>
+  <p>There are tons of online courses which teach web development at every level. Also, most of them are really cheap or even free! Here are the best of them:</p>
+  <ul>
+    <li><a href="https://www.udemy.com/course/the-web-developer-bootcamp/"><img src="img/udemy.png" alt=""></a>The Web Developer Bootcamp 2.0</li>
+    <li><a href="https://www.coursera.org/learn/html-css-javascript-for-web-developers"><img src="img/johnhop.png" alt=""></a>HTML, CSS, and Javascript for Web Developers</li>
+  </ul>
+</div>
 
 
 

--- a/useful-links/useful-links.html
+++ b/useful-links/useful-links.html
@@ -258,6 +258,7 @@
   <ul>
     <li><a href="https://www.udemy.com/course/the-web-developer-bootcamp/"><img src="img/udemy.png" alt=""></a>The Web Developer Bootcamp 2.0</li>
     <li><a href="https://www.coursera.org/learn/html-css-javascript-for-web-developers"><img src="img/johnhop.png" alt=""></a>HTML, CSS, and Javascript for Web Developers</li>
+    <li>.</li> <!-- Share your information here -->
   </ul>
 </div>
 

--- a/useful-links/useful-links.html
+++ b/useful-links/useful-links.html
@@ -8,6 +8,10 @@
   <link rel="stylesheet" href="useful-links.css" />
   <title>Useful Links</title>
 </head>
+
+
+
+
 <body>
   <header class="header animate__animated animate__fadeInDown">
     <div class="header-container flex-between">
@@ -18,6 +22,9 @@
       <a class="back-button" href="../index.html">HOME</a>
     </div>
   </header>
+
+
+
 
   <header class="menu">
     <input type="checkbox" id="menu" checked>
@@ -35,6 +42,10 @@
       </ul>
     </div>
   </header>
+
+
+
+
 
   <h1>Useful links for developers</h1>
   <img id="cover-img" src="img/cover.jpg" alt="">
@@ -66,9 +77,17 @@
     <p>A short introduction to the command line <a href="https://learntocodewith.me/getting-started/topics/command-line/">for beginners</a>.</p>
     <p>To make your contributions correctly, we recommend that you watch the following video:</p>
     <iframe width="560" height="315" src="https://www.youtube.com/embed/RGOj5yH7evk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  </div>
+  </div> <!-- End Description -->
 
+
+
+
+  
+<!-- Container for all of the links -->
   <div class="info-container">
+
+
+    <!-- Useful websites -->
     <div class="list">
       <div class="info-header">
         <img src="img/web.png" alt="">
@@ -88,6 +107,9 @@
       </ul>
     </div>
 
+
+
+<!-- Websites to learn for free -->
     <div class="list">
       <div class="info-header">
         <img src="img/study.png" alt="">
@@ -101,6 +123,10 @@
         <li>.</li> <!-- Share your information here -->
       </ul>
     </div>
+
+
+
+    <!-- Books -->
     <div class="list">
       <div class="info-header">
         <img src="img/books.png" alt="">
@@ -108,7 +134,12 @@
       </div>
       <p>Maybe sometimes skipping concepts, basic and not so much, is a good way to accelerate learning, but there are times when this has consequences and makes us get stuck in learning, in these cases it is best to take time to read a book relaxed .</p>
     </div>
+<!-- The rest of the section is down below -->
 
+
+
+
+<!-- Online Courses -->
     <div class="list">
       <div class="info-header">
         <img src="img/online-course.png" alt="">
@@ -121,6 +152,10 @@
       </ul>
     </div>
 
+
+
+
+<!-- Rest of book section -->
     <div class="container-of-all-cards">
       <div class="card-container">
         <figure>
@@ -197,6 +232,9 @@
     </div>
 
 
+
+<!-- Youtube -->
+
     <div class="list">
       <div class="info-header">
         <img src="img/youtube.png" alt="">
@@ -213,6 +251,11 @@
       </ul>
     </div>
 
+
+
+
+
+<!-- Podcasts -->
     <div class="list">
       <div class="info-header">
         <img src="img/podcast.png" alt="">
@@ -226,6 +269,10 @@
       </ul>
     </div>
 
+
+
+
+<!-- Challenges -->
     <div class="list">
       <div class="info-header">
         <img src="img/challenge.png" alt="">
@@ -237,11 +284,16 @@
         <li><a href="https://edabit.com/" target="_blank"><img src="img/edabit.png" alt=""></a>Edabit: Code challenges &amp; algorithms</li>
         <li><a href="https://www.codingame.com/" target="_blank"> <img src="img/CodinGame_logo.svg.png" alt=""></a>Codingame: Improve your programming skills while having fun</li>
         <li><a href="https://www.hackerrank.com" target="_blank"><img src="img/HackerRank_logo.png" alt=""></a>HackerRank: Solve challenges, algorithms</li> <!-- Share your information here -->
+
+
         <li><a href="https://www.topcoder.com/" target="_blank"><img src="img/topcoder.png" alt=""></a>TopCoder: Solve algorithms, competitive programming</li> <!-- Share your information here -->
         <li>.</li> <!-- Share your information here -->
       </ul>
     </div>
 
+
+
+<!-- Mobile Apps -->
     <div class="list">
       <div class="info-header">
         <img src="img/mobil.png" alt="">
@@ -255,6 +307,9 @@
       </ul>
     </div>
 
+
+
+<!-- Games -->
     <div class="list">
       <div class="info-header">
         <img src="img/games.png" alt="">
@@ -269,8 +324,8 @@
         <li><a href="https://www.codingame.com/start" target="_blank"><img src="img/CodinGame_logo.svg.png" alt=""></a>CodinGame: Learn to code while playing game</li>
         <li>.</li> <!-- Share your information here -->
       </ul>
-    </div>
-  </div>
+    </div>  <!-- End of Games Section -->
+  </div> <!-- End Container for all links-->
   <footer></footer>
 </body>
 </html>

--- a/useful-links/useful-links.html
+++ b/useful-links/useful-links.html
@@ -144,6 +144,9 @@
 
 <!-- Rest of book section -->
     <div class="container-of-all-cards">
+
+
+<!-- Javascript for Kids-->
       <div class="card-container">
         <figure>
           <img class="front" src="img/javascriptforkids.jpg" alt="">
@@ -154,6 +157,9 @@
           </figcaption>
         </figure>
       </div>
+
+
+<!-- Learn Python the Hard Way -->
       <div class="card-container">
       <figure>
         <img class="front" src="img/learnpythonthehardway.jpg" alt="">
@@ -164,6 +170,9 @@
         </figcaption>
       </figure>
       </div>
+
+
+<!-- JavaScript and JQuery -->
       <div class="card-container">
       <figure>
         <img class="front" src="img/javascript&jquery.jpg" alt="">
@@ -174,6 +183,11 @@
         </figcaption>
       </figure>
       </div>
+
+
+
+
+<!-- HTML and CSS -->
       <div class="card-container">
       <figure>
         <img class="front" src="img/html&css.jpg" alt="">
@@ -184,6 +198,11 @@
         </figcaption>
       </figure>
       </div>
+
+
+
+
+  <!-- Learning Web Design -->
       <div class="card-container">
       <figure>
         <img class="front" src="img/learningwebdesign.jpg" alt="">
@@ -194,7 +213,9 @@
         </figcaption>
       </figure>
       </div>
-      <div class="card-container"> <!-- Copy and paste the entire container and fill in the blanks -->
+
+  <!-- Cracking the Coding Interview-->
+      <div class="card-container">
         <figure>
           <img class="front" src="img/crackingthecodinginterviewcover.jpg" alt="Cover for cracking the coding interview by Gayle Laakmann McDowell.">
           <figcaption class="back">
@@ -203,8 +224,9 @@
             <p>It describes typical problems in computer science that are often asked during coding interviews, typically on a whiteboard during job interviews at big technology companies such as Google, Apple, Microsoft, Amazon.com, Facebook and Palantir Technologies.</p>
           </figcaption>
         </figure>
-        </div>
+      </div>
 
+      
       <!-- <div class="card-container"> Copy and paste the entire container and fill in the blanks
       <figure>
         <img class="front" src="#" alt=""> Put the cover here
@@ -220,7 +242,7 @@
 
 
 
-    
+
 <!-- Online Courses -->
 <div class="list">
   <div class="info-header">

--- a/useful-links/useful-links.html
+++ b/useful-links/useful-links.html
@@ -8,10 +8,6 @@
   <link rel="stylesheet" href="useful-links.css" />
   <title>Useful Links</title>
 </head>
-
-
-
-
 <body>
   <header class="header animate__animated animate__fadeInDown">
     <div class="header-container flex-between">
@@ -22,10 +18,6 @@
       <a class="back-button" href="../index.html">HOME</a>
     </div>
   </header>
-
-
-
-
   <header class="menu">
     <input type="checkbox" id="menu" checked>
     <div class="btn-menu"><label for="menu">MENU</label></div>
@@ -42,17 +34,10 @@
       </ul>
     </div>
   </header>
-
-
-
-
-
   <h1>Useful links for developers</h1>
   <img id="cover-img" src="img/cover.jpg" alt="">
-
   <input type="checkbox" id="instructions" checked>
   <div class="btn-instructions"><label for="instructions">To start collaborating, click here</label></div>
-
   <div class="description">
     <p>This section is designed so that we can all share useful links or any useful information to progress on our path to being better developers.</p>
     <p>For example we can share the following:</p>
@@ -78,15 +63,8 @@
     <p>To make your contributions correctly, we recommend that you watch the following video:</p>
     <iframe width="560" height="315" src="https://www.youtube.com/embed/RGOj5yH7evk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div> <!-- End Description -->
-
-
-
-
-
 <!-- Container for all of the links -->
   <div class="info-container">
-
-
     <!-- Useful websites -->
     <div class="list">
       <div class="info-header">
@@ -106,9 +84,6 @@
         <li>.</li> <!-- Share your information here -->
       </ul>
     </div>
-
-
-
 <!-- Websites to learn for free -->
     <div class="list">
       <div class="info-header">
@@ -123,9 +98,6 @@
         <li>.</li> <!-- Share your information here -->
       </ul>
     </div>
-
-
-
     <!-- Books -->
     <div class="list">
       <div class="info-header">
@@ -134,18 +106,7 @@
       </div>
       <p>Maybe sometimes skipping concepts, basic and not so much, is a good way to accelerate learning, but there are times when this has consequences and makes us get stuck in learning, in these cases it is best to take time to read a book relaxed .</p>
     </div>
-<!-- The rest of the section is down below -->
-
-
-
-
-
-
-
-<!-- Rest of book section -->
     <div class="container-of-all-cards">
-
-
 <!-- Javascript for Kids-->
       <div class="card-container">
         <figure>
@@ -157,8 +118,6 @@
           </figcaption>
         </figure>
       </div>
-
-
 <!-- Learn Python the Hard Way -->
       <div class="card-container">
       <figure>
@@ -170,8 +129,6 @@
         </figcaption>
       </figure>
       </div>
-
-
 <!-- JavaScript and JQuery -->
       <div class="card-container">
       <figure>
@@ -183,10 +140,6 @@
         </figcaption>
       </figure>
       </div>
-
-
-
-
 <!-- HTML and CSS -->
       <div class="card-container">
       <figure>
@@ -198,10 +151,6 @@
         </figcaption>
       </figure>
       </div>
-
-
-
-
   <!-- Learning Web Design -->
       <div class="card-container">
       <figure>
@@ -213,7 +162,6 @@
         </figcaption>
       </figure>
       </div>
-
   <!-- Cracking the Coding Interview-->
       <div class="card-container">
         <figure>
@@ -225,9 +173,6 @@
           </figcaption>
         </figure>
       </div>  <!-- end of last book -->
-
-
-
 
 <!-- Add a Book Template
       <div class="card-container">
@@ -242,12 +187,7 @@
       </div> 
 -->
 
-
     </div>  <!-- end of container of all book cards -->
-
-
-
-
 <!-- Online Courses -->
 <div class="list">
   <div class="info-header">
@@ -261,11 +201,7 @@
     <li>.</li> <!-- Share your information here -->
   </ul>
 </div>
-
-
-
 <!-- Youtube -->
-
     <div class="list">
       <div class="info-header">
         <img src="img/youtube.png" alt="">
@@ -281,11 +217,6 @@
         <li>.</li> <!-- Share your information here -->
       </ul>
     </div>
-
-
-
-
-
 <!-- Podcasts -->
     <div class="list">
       <div class="info-header">
@@ -299,10 +230,6 @@
         <li>.</li> <!-- Share your information here -->
       </ul>
     </div>
-
-
-
-
 <!-- Challenges -->
     <div class="list">
       <div class="info-header">
@@ -319,9 +246,6 @@
         <li>.</li> <!-- Share your information here -->
       </ul>
     </div>
-
-
-
 <!-- Mobile Apps -->
     <div class="list">
       <div class="info-header">
@@ -335,9 +259,6 @@
         <li>.</li> <!-- Share your information here -->
       </ul>
     </div>
-
-
-
 <!-- Games -->
     <div class="list">
       <div class="info-header">

--- a/useful-links/useful-links.html
+++ b/useful-links/useful-links.html
@@ -224,20 +224,24 @@
             <p>It describes typical problems in computer science that are often asked during coding interviews, typically on a whiteboard during job interviews at big technology companies such as Google, Apple, Microsoft, Amazon.com, Facebook and Palantir Technologies.</p>
           </figcaption>
         </figure>
-      </div>
+      </div>  <!-- end of last book -->
 
-      
-      <!-- <div class="card-container"> Copy and paste the entire container and fill in the blanks
-      <figure>
-        <img class="front" src="#" alt=""> Put the cover here
-        <figcaption class="back">
-          <h4></h4> Put the title here
-          <hr>
-          <p></p> Put a description here
-        </figcaption>
-      </figure>
+
+
+
+<!-- Add a Book Template
+      <div class="card-container">
+        <figure>
+          <img class="front" src=" {image of front of book} " alt="">
+          <figcaption class="back">
+            <h4> {Title of Book} </h4>
+            <hr>
+            <p> {Description of Book} </p>
+          </figcaption>
+        </figure>
       </div> -->
 
+      
     </div>  <!-- end of container of all book cards -->
 
 

--- a/useful-links/useful-links.html
+++ b/useful-links/useful-links.html
@@ -314,10 +314,8 @@
         <li><a href="https://www.codewars.com/" target="_blank"><img src="img/codewars.png" alt=""></a>Codewars: Train to improve</li>
         <li><a href="https://edabit.com/" target="_blank"><img src="img/edabit.png" alt=""></a>Edabit: Code challenges &amp; algorithms</li>
         <li><a href="https://www.codingame.com/" target="_blank"> <img src="img/CodinGame_logo.svg.png" alt=""></a>Codingame: Improve your programming skills while having fun</li>
-        <li><a href="https://www.hackerrank.com" target="_blank"><img src="img/HackerRank_logo.png" alt=""></a>HackerRank: Solve challenges, algorithms</li> <!-- Share your information here -->
-
-
-        <li><a href="https://www.topcoder.com/" target="_blank"><img src="img/topcoder.png" alt=""></a>TopCoder: Solve algorithms, competitive programming</li> <!-- Share your information here -->
+        <li><a href="https://www.hackerrank.com" target="_blank"><img src="img/HackerRank_logo.png" alt=""></a>HackerRank: Solve challenges, algorithms</li>
+        <li><a href="https://www.topcoder.com/" target="_blank"><img src="img/topcoder.png" alt=""></a>TopCoder: Solve algorithms, competitive programming</li>
         <li>.</li> <!-- Share your information here -->
       </ul>
     </div>


### PR DESCRIPTION
The new Online Courses ended up breaking the Books section in two.  I rearranged them and double-checked all of the `<div>`s had matching closing tags.

There is now an issue with hovering over a book.  The transformation works correctly, but the back of the book disappears too quickly.  We must have added a bug.  I'll work on it.

I also needed a gitignore file for my local repository because my live server was making a json file.  I don't know how to keep the commit local and it was pulled into the pull request here.  But, if we don't have one yet, it won't hurt anything.